### PR TITLE
Add Hide flavour variants option (skip cosmetic recipe siblings)

### DIFF
--- a/ecocraft/Components/Pages/PriceCalculator.razor
+++ b/ecocraft/Components/Pages/PriceCalculator.razor
@@ -438,6 +438,12 @@
                                             <MudCheckBox T="bool" Value="_hideBlueprints" Variant="Variant.Outlined" ValueChanged="OnHideBlueprintsChanged"/>
                                         </MudStack>
                                         <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                                            <MudTooltip Text="@LocalizationService.GetTranslation("PriceCalculator.HideFlavourVariants.Tooltip")">
+                                                <MudText Class="tooltip-text">@LocalizationService.GetTranslation("PriceCalculator.HideFlavourVariants.HideFlavourVariants")</MudText>
+                                            </MudTooltip>
+                                            <MudCheckBox T="bool" Value="_selectedDataContext.UserSettings.First().HideFlavourVariants" Variant="Variant.Outlined" ValueChanged="OnOptionHideFlavourVariantsChanged"/>
+                                        </MudStack>
+                                        <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
                                             <MudTooltip Text="@LocalizationService.GetTranslation("PriceCalculator.LevelAccessible.Tooltip")">
                                                 <MudText Class="tooltip-text">@LocalizationService.GetTranslation("PriceCalculator.LevelAccessible.LevelAccessible")</MudText>
                                             </MudTooltip>
@@ -2303,6 +2309,20 @@
     private async Task OnOptionOnlyLevelChanged()
     {
         _selectedDataContext!.UserSettings.First().OnlyLevelAccessibleRecipes = !_selectedDataContext!.UserSettings.First().OnlyLevelAccessibleRecipes;
+
+        await EcoCraftDbContext.ContextSaveAsync(EcoCraftDbFactory, context =>
+        {
+            UserSettingDbService.UpdateAll(context, _selectedDataContext!.UserSettings.First());
+            UserServerDataService.RecalculateUserRecipes(context, _selectedDataContext!, ContextService.CurrentServerData!);
+            return Task.CompletedTask;
+        });
+
+        await RequestCalculate(CalculateTriggerOrigin.SettingsChange);
+    }
+
+    private async Task OnOptionHideFlavourVariantsChanged()
+    {
+        _selectedDataContext!.UserSettings.First().HideFlavourVariants = !_selectedDataContext!.UserSettings.First().HideFlavourVariants;
 
         await EcoCraftDbContext.ContextSaveAsync(EcoCraftDbFactory, context =>
         {

--- a/ecocraft/Migrations/20260509131842_AddHideFlavourVariants.Designer.cs
+++ b/ecocraft/Migrations/20260509131842_AddHideFlavourVariants.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ecocraft.Models;
@@ -11,9 +12,11 @@ using ecocraft.Models;
 namespace ecocraft.Migrations
 {
     [DbContext(typeof(EcoCraftDbContext))]
-    partial class EcoCraftDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260509131842_AddHideFlavourVariants")]
+    partial class AddHideFlavourVariants
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ecocraft/Migrations/20260509131842_AddHideFlavourVariants.cs
+++ b/ecocraft/Migrations/20260509131842_AddHideFlavourVariants.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ecocraft.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHideFlavourVariants : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "HideFlavourVariants",
+                table: "UserSetting",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HideFlavourVariants",
+                table: "UserSetting");
+        }
+    }
+}

--- a/ecocraft/Models/Models.cs
+++ b/ecocraft/Models/Models.cs
@@ -778,6 +778,7 @@ public class UserSetting
     public bool DisplayNonSkilledRecipes { get; set; } = false;
     public bool OnlyLevelAccessibleRecipes { get; set; } = false;
     public bool ApplyMarginBetweenSkills { get; set; } = true;
+    public bool HideFlavourVariants { get; set; } = false;
 
     public DataContext DataContext { get; set; }
 }

--- a/ecocraft/Services/DbServices/UserSettingDbService.cs
+++ b/ecocraft/Services/DbServices/UserSettingDbService.cs
@@ -52,6 +52,7 @@ public class UserSettingDbService(IDbContextFactory<EcoCraftDbContext> factory) 
 			DisplayNonSkilledRecipes = userSetting.DisplayNonSkilledRecipes,
 			OnlyLevelAccessibleRecipes = userSetting.OnlyLevelAccessibleRecipes,
 			ApplyMarginBetweenSkills = userSetting.ApplyMarginBetweenSkills,
+			HideFlavourVariants = userSetting.HideFlavourVariants,
 		};
 	}
 

--- a/ecocraft/Services/UserServerDataService.cs
+++ b/ecocraft/Services/UserServerDataService.cs
@@ -150,10 +150,25 @@ public class UserServerDataService(
 
     public void RecalculateUserRecipes(EcoCraftDbContext context, DataContext dataContext, Server server)
     {
+        var hideFlavourVariants = dataContext.UserSettings.First().HideFlavourVariants;
+
+        // Only skip a flavour when the family has a canonical sibling — otherwise items
+        // producible only via flavour recipes (e.g. ParticipationTrophy) would vanish.
+        var familiesWithDefault = hideFlavourVariants
+            ? server.Recipes.Where(r => r.IsDefault).Select(r => r.FamilyName).ToHashSet()
+            : new HashSet<string>();
+
+        bool IsFlavourSkippable(Recipe r) =>
+            hideFlavourVariants && !r.IsDefault && familiesWithDefault.Contains(r.FamilyName);
+
         // We remove all recipes that does not meet the requirements
         foreach (var userRecipe in dataContext.UserRecipes.ToList())
         {
             if (userRecipe.Recipe.Skill is not null && userRecipe.Recipe.SkillLevel > dataContext.UserSkills.First(us => us.Skill == userRecipe.Recipe.Skill).Level)
+            {
+                RemoveUserRecipe(context, userRecipe);
+            }
+            else if (IsFlavourSkippable(userRecipe.Recipe))
             {
                 RemoveUserRecipe(context, userRecipe);
             }
@@ -172,7 +187,7 @@ public class UserServerDataService(
                 recipesToAdd = recipesToAdd.Where(r => r.SkillLevel <= userSkill.Level).ToList();
             }
 
-            recipesToAdd = recipesToAdd.Where(r => !selectedRecipes.Contains(r)).ToList();
+            recipesToAdd = recipesToAdd.Where(r => !selectedRecipes.Contains(r) && !IsFlavourSkippable(r)).ToList();
 
             foreach (var recipe in recipesToAdd)
             {

--- a/ecocraft/wwwroot/assets/lang/en_US.json
+++ b/ecocraft/wwwroot/assets/lang/en_US.json
@@ -374,6 +374,10 @@
             "Tooltip": "Hide blueprint recipes from the items to sell.",
             "HideBlueprints": "Hide blueprints"
         },
+        "HideFlavourVariants": {
+            "Tooltip": "Skip flavour-variant recipes (e.g. Birch/Oak/Hardwood/Softwood versions of the same item) so only the canonical recipe of each family is priced. A flavour is only skipped when its family has a canonical sibling — items producible only via flavour recipes are kept.",
+            "HideFlavourVariants": "Hide flavour variants"
+        },
         "LevelAccessible": {
             "Tooltip": "Only display recipes that are allowed by your skills levels.",
             "LevelAccessible": "Only level-accessible recipes"


### PR DESCRIPTION
## Summary

Adds a per-DataContext `Hide flavour variants` option that skips cosmetic recipe siblings (Hardwood/Softwood/Birch/Oak/... versions of the same item) so only the canonical recipe of each family is priced.

When players export prices to the in-game shop, families like *Composite Lumber Chair* currently produce 13 entries (1 main + 12 wood-flavour cosmetics). Players who only want to sell the generic version end up with a polluted listing. With the toggle on, the chair family collapses to a single entry. The orphan-safe rule preserves recipes whose family has no canonical alternative (e.g. `ParticipationTrophyRecipe` is `IsDefault=true`, so it's never touched).

## How it works

The skip rule:

```
recipe is "flavour-skippable" iff
    !recipe.IsDefault
    AND there exists r' in same FamilyName with r'.IsDefault = true
```

This relies on the `FamilyName` and `IsDefault` fields already imported by `ImportDataService` from the EcoGnomeMod export — no new naming heuristics or string parsing.

## Where the change attaches

The toggle mirrors the existing `OnlyLevelAccessibleRecipes` pattern:

- New `bool HideFlavourVariants` column on `UserSetting` (one EF migration, default `false`).
- Filter applied at recipe-population time in `UserServerDataService.RecalculateUserRecipes` — the same method `OnlyLevelAccessibleRecipes` extends.
- The cascade through `UserRecipe → UserElement → GetCategorizedItemOrTags → /api/eco/categories-items-v2` happens automatically. **Zero changes to `Controllers/eco.cs` or `PriceCalculatorService.cs`.**
- New `OnOptionHideFlavourVariantsChanged` handler is a 1:1 copy of `OnOptionOnlyLevelChanged` (same DbService write, same recalc trigger origin).
- UI: a `MudCheckBox` row placed between *Hide blueprints* and *Only level-accessible recipes* in the Options panel, with explanatory tooltip.

## Diff scope

| File | Change |
|---|---|
| `Models/Models.cs` | +1 line (`UserSetting.HideFlavourVariants`) |
| `Services/DbServices/UserSettingDbService.cs` | +1 line (`CloneForDb`) |
| `Services/UserServerDataService.cs` | +16 lines (rule in `RecalculateUserRecipes`) |
| `Components/Pages/PriceCalculator.razor` | +20 lines (markup row + handler) |
| `wwwroot/assets/lang/en_US.json` | +4 lines (translation keys) |
| `Migrations/…AddHideFlavourVariants` | new migration (single column, default false) |

## Verification

Tested against the shipped `eco_gnome_data.json` fixture (1453 recipes, 1088 families):

| Test | Result |
|---|---|
| Total recipes loaded | 1453 ✓ |
| Distribution of `IsDefault` per family | every family has exactly 1 default ✓ |
| Orphan-flavour families (anomaly) | 0 ✓ |
| Multi-default families (anomaly) | 0 ✓ |
| Recipes flavour-skippable under the rule | 365 (25.1% of total) |
| Cross-recipe ingredient breakage | 0 — no surviving recipe loses an ingredient producer |
| Single-recipe-family canary | 0 false positives |
| `Composite Lumber Chair` family | 13 → 1 with toggle on |
| `ParticipationTrophyRecipe` (consumes `RedwoodLogItem`) | preserved (IsDefault=true) |
| `HideFlavourVariants` migration applies cleanly | ✓ |
| `dotnet build` | 0 errors |

## Translations

Only `en_US` added in this PR. `LocalizationService.GetTranslation` already falls back to `en_US` for any missing key in other languages, so the toggle is functional everywhere out of the box. Happy to add other locales if you want them in this PR — let me know which.

## Open question for maintainers

The rule treats `Recipe.IsDefault` as authoritative for "is this the canonical family member." This is the first place in the codebase that reads `IsDefault` for filtering — until now the field has only been imported and stored, never queried. The fixture is internally consistent (every family has exactly one default), but if you've seen modded servers where the data isn't this clean, the orphan-safe guard in the rule should still keep things sane (a flavour is never skipped unless its family has at least one default sibling).
