### PR TITLE
Admin-locked recipe output distribution & min/max price clamping (#84, #85)

### DIFF
--- a/ecocraft/Components/Dialog/RecipeDialog.razor
+++ b/ecocraft/Components/Dialog/RecipeDialog.razor
@@ -12,6 +12,8 @@
 @inject UserElementDbService UserElementDbService
 @inject UserPriceDbService UserPriceDbService
 @inject UserRecipeDbService UserRecipeDbService
+@inject RecipeDbService RecipeDbService
+@inject ElementDbService ElementDbService
 @inject IDbContextFactory<EcoCraftDbContext> EcoCraftDbFactory
 
 <MudDialog Style="min-height: 500px;" Class="pb-4">
@@ -138,8 +140,8 @@
                                             <MudNumericField T="decimal?"
                                                              Class="rectangle-input small-adornment"
                                                              Style="@($"width: 90px; color: var({(context.IsMarginPrice ? "--mud-palette-tertiary" : "--mud-palette-primary")})")"
-                                                             Disabled="@(!canContributePrice)"
-                                                             HideSpinButtons="@(!canContributePrice)"
+                                                             Disabled="@(!canContributePrice || AdminServerMode)"
+                                                             HideSpinButtons="@(!canContributePrice || AdminServerMode)"
                                                              Value="@context.Price"
                                                              Immediate="true"
                                                              DebounceInterval="150"
@@ -174,6 +176,7 @@
                                     <MudTooltip Text="@(!context.IsReintegrated ? LocalizationService.GetTranslation("RecipeDialog.ReintegratedToolTip.True") : LocalizationService.GetTranslation("RecipeDialog.ReintegratedToolTip.False"))">
                                         <MudIconButton Icon="@MDIIcons.Filled.ChevronDoubleRight"
                                                        Size="Size.Small"
+                                                       Disabled="@IsAdminLockedForPlayer"
                                                        OnClick="@(() => ChangeReintegrate(context, !context.IsReintegrated))"/>
                                     </MudTooltip>
                                 }
@@ -302,6 +305,7 @@
                                     <MudIconButton Size="Size.Small"
                                                    tabindex="-1"
                                                    Icon="@MDIIcons.Filled.ChevronDoubleLeft"
+                                                   Disabled="@IsAdminLockedForPlayer"
                                                    OnClick="@(() => ChangeReintegrate(context, !context.IsReintegrated))"/>
                                 </MudTooltip>
                             }
@@ -341,19 +345,29 @@
                         <MudTd Class="px-1">
                             @if (GetProductUserElements().Count > 1)
                             {
-                                <MudNumericField T="decimal"
-                                                 Class="rectangle-input"
-                                                 Style="width: 90px; color: var(--mud-palette-primary)"
-                                                 Format="0.##"
-                                                 Converter="@CultureInvariantConverter.DotOrCommaDecimal"
-                                                 Adornment="Adornment.End"
-                                                 AdornmentText="% "
-                                                 Min="@((_currentUserRecipe?.LockShare ?? false) ? Decimal.MinValue : 0)"
-                                                 Max="@((_currentUserRecipe?.LockShare ?? false) ? Decimal.MaxValue : 100)"
-                                                 Variant="Variant.Outlined"
-                                                 Step="@(0.1m)"
-                                                 Value="@(context.Share * 100)"
-                                                 ValueChanged="@(v => UpdateShare(context, v / 100))"/>
+                                <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                                    <MudNumericField T="decimal"
+                                                     Class="rectangle-input"
+                                                     Style="width: 90px; color: var(--mud-palette-primary)"
+                                                     Format="0.##"
+                                                     Disabled="@IsAdminLockedForPlayer"
+                                                     HideSpinButtons="@IsAdminLockedForPlayer"
+                                                     Converter="@CultureInvariantConverter.DotOrCommaDecimal"
+                                                     Adornment="Adornment.End"
+                                                     AdornmentText="% "
+                                                     Min="@(IsShareFreeForm ? Decimal.MinValue : 0)"
+                                                     Max="@(IsShareFreeForm ? Decimal.MaxValue : 100)"
+                                                     Variant="Variant.Outlined"
+                                                     Step="@(0.1m)"
+                                                     Value="@(context.Share * 100)"
+                                                     ValueChanged="@(v => UpdateShare(context, v / 100))"/>
+                                    @if (IsAdminLockedForPlayer)
+                                    {
+                                        <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.AdminLockedTooltip")">
+                                            <MudIcon Icon="@MDIIcons.Outline.Information" Color="Color.Warning" Size="Size.Small" Class="d-flex align-center"/>
+                                        </MudTooltip>
+                                    }
+                                </MudStack>
                             }
                         </MudTd>
                         <!-- price -->
@@ -375,39 +389,55 @@
                                 <MudStack Row Spacing="0" Style="min-height: 24px">
                                     @if (GetProductUserElements().Count > 1)
                                     {
-                                        <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.HonestTooltip")">
-                                            <MudIconButton Size="Size.Small"
-                                                           Icon="@MDIIcons.Filled.ChartPie"
-                                                           OnClick="@(() => Honest())"/>
-                                        </MudTooltip>
-                                        <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.FirstOnlyTooltip")">
-                                            <MudIconButton Size="Size.Small"
-                                                           Icon="@MDIIcons.Filled.Numeric1Box"
-                                                           OnClick="@(() => FirstOnly())"/>
-                                        </MudTooltip>
-                                        <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.EqualityTooltip")">
-                                            <MudIconButton Size="Size.Small"
-                                                           Icon="@MDIIcons.Filled.EqualBox"
-                                                           OnClick="@(() => Equality())"/>
-                                        </MudTooltip>
-
-                                        var firstQuantity = GetProductUserElements().First().Element.Quantity;
-
-                                        @if (GetProductUserElements().Any(ue => ue.Element.Quantity != firstQuantity))
+                                        @if (!IsAdminLockedForPlayer)
                                         {
-                                            <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.EquilibrateTooltip")">
+                                            <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.HonestTooltip")">
                                                 <MudIconButton Size="Size.Small"
-                                                               Icon="@MDIIcons.Filled.Equalizer"
-                                                               OnClick="@(() => Equilibrate())"/>
+                                                               Icon="@MDIIcons.Filled.ChartPie"
+                                                               OnClick="@(() => Honest())"/>
                                             </MudTooltip>
+                                            <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.FirstOnlyTooltip")">
+                                                <MudIconButton Size="Size.Small"
+                                                               Icon="@MDIIcons.Filled.Numeric1Box"
+                                                               OnClick="@(() => FirstOnly())"/>
+                                            </MudTooltip>
+                                            <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.EqualityTooltip")">
+                                                <MudIconButton Size="Size.Small"
+                                                               Icon="@MDIIcons.Filled.EqualBox"
+                                                               OnClick="@(() => Equality())"/>
+                                            </MudTooltip>
+
+                                            var firstQuantity = GetProductUserElements().First().Element.Quantity;
+
+                                            @if (GetProductUserElements().Any(ue => ue.Element.Quantity != firstQuantity))
+                                            {
+                                                <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.EquilibrateTooltip")">
+                                                    <MudIconButton Size="Size.Small"
+                                                                   Icon="@MDIIcons.Filled.Equalizer"
+                                                                   OnClick="@(() => Equilibrate())"/>
+                                                </MudTooltip>
+                                            }
                                         }
 
-                                        <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.UnlockTooltip")">
-                                            <MudIconButton Size="Size.Small"
-                                                           Class="ml-3"
-                                                           Icon="@((_currentUserRecipe?.LockShare ?? false) ? MDIIcons.Filled.LockOff : MDIIcons.Filled.Lock)"
-                                                           OnClick="@(() => ToggleLock())"/>
-                                        </MudTooltip>
+                                        @if (AdminServerMode)
+                                        {
+                                            <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.AdminLockTooltip")">
+                                                <MudIconButton Size="Size.Small"
+                                                               Class="ml-3"
+                                                               Color="@(Recipe.IsShareLocked ? Color.Warning : Color.Default)"
+                                                               Icon="@(Recipe.IsShareLocked ? MDIIcons.Filled.Lock : MDIIcons.Filled.LockOff)"
+                                                               OnClick="@(() => ToggleAdminLock())"/>
+                                            </MudTooltip>
+                                        }
+                                        else if (!Recipe.IsShareLocked)
+                                        {
+                                            <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.UnlockTooltip")">
+                                                <MudIconButton Size="Size.Small"
+                                                               Class="ml-3"
+                                                               Icon="@((_currentUserRecipe?.LockShare ?? false) ? MDIIcons.Filled.LockOff : MDIIcons.Filled.Lock)"
+                                                               OnClick="@(() => ToggleLock())"/>
+                                            </MudTooltip>
+                                        }
                                     }
                                 </MudStack>
                             </MudTd>
@@ -418,7 +448,7 @@
                 </MudItem>
             </MudGrid>
 
-            @if (Recipe.Elements.Any(e => Math.Truncate(e.Quantity.GetBaseValue()) != e.Quantity.GetBaseValue() || Math.Truncate(e.Quantity.GetDynamicValue(DataContext)) != e.Quantity.GetDynamicValue(DataContext)))
+            @if (!AdminServerMode && Recipe.Elements.Any(e => Math.Truncate(e.Quantity.GetBaseValue()) != e.Quantity.GetBaseValue() || Math.Truncate(e.Quantity.GetDynamicValue(DataContext)) != e.Quantity.GetDynamicValue(DataContext)))
             {
                 <MudStack Row Class="mt-n6" AlignItems="AlignItems.Center">
                     <MudText>Crafted by quantity:</MudText>
@@ -449,6 +479,19 @@
 
     [Parameter]
     public Func<string, Task>? RecalculateRequested { get; set; }
+
+    // When true, the dialog is opened from the server admin page: share/reintegration edits
+    // are written to the server-level Element defaults (and pushed to every player when the
+    // recipe is admin-locked) instead of being a per-player preference.
+    [Parameter]
+    public bool AdminServerMode { get; set; }
+
+    // Editing is free-form (no auto-rebalance to 100%) when the distribution is locked.
+    // Admin lock (Recipe.IsShareLocked) drives it in admin mode; the per-player LockShare otherwise.
+    private bool IsShareFreeForm => AdminServerMode ? Recipe.IsShareLocked : (_currentUserRecipe?.LockShare ?? false);
+
+    // A normal player viewing a recipe whose distribution is locked by the server admin: read-only.
+    private bool IsAdminLockedForPlayer => !AdminServerMode && Recipe.IsShareLocked;
 
     private const int PriceSaveDebounceMs = 250;
     private readonly Dictionary<Guid, CancellationTokenSource> _priceSaveDebounceByUserPriceId = [];
@@ -642,6 +685,72 @@
         StateHasChanged();
     }
 
+    // Admin: toggle the server-level lock of this recipe's output distribution.
+    // When enabling, the current distribution is frozen onto every player of the server.
+    private async Task ToggleAdminLock()
+    {
+        Recipe.IsShareLocked = !Recipe.IsShareLocked;
+
+        await PersistAsync(context =>
+        {
+            RecipeDbService.UpdateShareLock(context, Recipe);
+            return Task.CompletedTask;
+        });
+
+        if (Recipe.IsShareLocked)
+        {
+            await PersistAdminOutputConfig();
+        }
+
+        RefreshComputedState();
+        StateHasChanged();
+    }
+
+    // Admin: write the current output Share / IsReintegrated of every product onto the
+    // server-level Element defaults, and push them to all players when the recipe is locked.
+    private async Task PersistAdminOutputConfig()
+    {
+        var outputElements = Recipe.Elements.Where(e => e.IsProduct()).ToList();
+
+        foreach (var element in outputElements)
+        {
+            var userElement = GetUserElement(element);
+            element.DefaultShare = userElement.Share;
+            element.DefaultIsReintegrated = userElement.IsReintegrated;
+        }
+
+        await PersistAsync(context =>
+        {
+            foreach (var element in outputElements)
+            {
+                ElementDbService.UpdateDefaultShareConfig(context, element);
+            }
+            return Task.CompletedTask;
+        });
+
+        if (Recipe.IsShareLocked)
+        {
+            await PushOutputConfigToAllPlayers(outputElements);
+        }
+    }
+
+    // Admin: overwrite every player's UserElement for these outputs with the server defaults.
+    // ElementId is globally unique to this server, so no extra server filter is needed.
+    private async Task PushOutputConfigToAllPlayers(List<Element> outputElements)
+    {
+        await EcoCraftDbContext.ContextSaveAsync(EcoCraftDbFactory, async context =>
+        {
+            foreach (var element in outputElements)
+            {
+                await context.UserElements
+                    .Where(ue => ue.ElementId == element.Id)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(x => x.Share, element.DefaultShare)
+                        .SetProperty(x => x.IsReintegrated, element.DefaultIsReintegrated));
+            }
+        });
+    }
+
     private decimal ElementSum(List<UserElement> userElements, bool reverseDeduction = false, bool withReduction = true)
     {
         var ingredientCostSum = userElements.Sum(ue => ue.Price
@@ -729,7 +838,7 @@
     private async Task UpdateShare(UserElement ue, decimal value)
     {
         var userElements = GetProductUserElements();
-        var lockShare = _currentUserRecipe?.LockShare ?? false;
+        var lockShare = IsShareFreeForm;
 
         ue.Share = lockShare ? value : Math.Clamp(value, 0, 1);
 
@@ -819,6 +928,11 @@
             }
             return Task.CompletedTask;
         });
+
+        if (AdminServerMode)
+        {
+            await PersistAdminOutputConfig();
+        }
     }
 
     private async Task RecalculateFromDialog(string origin)

--- a/ecocraft/Components/Dialog/RecipeDialog.razor
+++ b/ecocraft/Components/Dialog/RecipeDialog.razor
@@ -173,12 +173,20 @@
                             <MudTd Style="width: 0; padding: 0;" Class="@($"pa-0 {(context.Element.IsProduct() ? "border-l-1" : "")}")">
                                 @if (context.Element.IsProduct())
                                 {
-                                    <MudTooltip Text="@(!context.IsReintegrated ? LocalizationService.GetTranslation("RecipeDialog.ReintegratedToolTip.True") : LocalizationService.GetTranslation("RecipeDialog.ReintegratedToolTip.False"))">
-                                        <MudIconButton Icon="@MDIIcons.Filled.ChevronDoubleRight"
-                                                       Size="Size.Small"
-                                                       Disabled="@IsAdminLockedForPlayer"
-                                                       OnClick="@(() => ChangeReintegrate(context, !context.IsReintegrated))"/>
-                                    </MudTooltip>
+                                    <MudStack Row Spacing="0" AlignItems="AlignItems.Center">
+                                        <MudTooltip Text="@(!context.IsReintegrated ? LocalizationService.GetTranslation("RecipeDialog.ReintegratedToolTip.True") : LocalizationService.GetTranslation("RecipeDialog.ReintegratedToolTip.False"))">
+                                            <MudIconButton Icon="@MDIIcons.Filled.ChevronDoubleRight"
+                                                           Size="Size.Small"
+                                                           Disabled="@IsAdminLockedForPlayer"
+                                                           OnClick="@(() => ChangeReintegrate(context, !context.IsReintegrated))"/>
+                                        </MudTooltip>
+                                        @if (IsAdminLockedForPlayer)
+                                        {
+                                            <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.AdminLockedTooltip")">
+                                                <MudIcon Icon="@MDIIcons.Outline.Information" Color="Color.Warning" Size="Size.Small" Class="d-flex align-center"/>
+                                            </MudTooltip>
+                                        }
+                                    </MudStack>
                                 }
                             </MudTd>
                         </RowTemplate>
@@ -301,13 +309,21 @@
                         <MudTd Style="height: 0; width: 0; vertical-align: top; padding: 9px 0 0;" Class="@(GetProductUserElements().Count > 1 ? "border-r-1" : "")">
                             @if (GetProductUserElements().Count > 1)
                             {
-                                <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.ReintegratedToolTip.True")">
-                                    <MudIconButton Size="Size.Small"
-                                                   tabindex="-1"
-                                                   Icon="@MDIIcons.Filled.ChevronDoubleLeft"
-                                                   Disabled="@IsAdminLockedForPlayer"
-                                                   OnClick="@(() => ChangeReintegrate(context, !context.IsReintegrated))"/>
-                                </MudTooltip>
+                                <MudStack Row Spacing="0" AlignItems="AlignItems.Center">
+                                    <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.ReintegratedToolTip.True")">
+                                        <MudIconButton Size="Size.Small"
+                                                       tabindex="-1"
+                                                       Icon="@MDIIcons.Filled.ChevronDoubleLeft"
+                                                       Disabled="@IsAdminLockedForPlayer"
+                                                       OnClick="@(() => ChangeReintegrate(context, !context.IsReintegrated))"/>
+                                    </MudTooltip>
+                                    @if (IsAdminLockedForPlayer)
+                                    {
+                                        <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.AdminLockedTooltip")">
+                                            <MudIcon Icon="@MDIIcons.Outline.Information" Color="Color.Warning" Size="Size.Small" Class="d-flex align-center"/>
+                                        </MudTooltip>
+                                    }
+                                </MudStack>
                             }
                         </MudTd>
                         <!-- quantity -->
@@ -337,9 +353,17 @@
                         </MudTd>
                         <!-- unit price -->
                         <MudTd Class="px-1">
-                            <MudText Typo="Typo.body2" Color="Color.Primary" Style="text-align: end;">
-                                @(context.Price is not null ? Math.Round((decimal)context.Price!, 2, MidpointRounding.AwayFromZero).ToString("0.##") + " $/u" : "")
-                            </MudText>
+                            <MudStack Row AlignItems="AlignItems.Center" Spacing="1" Justify="Justify.FlexEnd">
+                                <MudText Typo="Typo.body2" Color="Color.Primary" Style="text-align: end;">
+                                    @(context.Price is not null ? Math.Round((decimal)context.Price!, 2, MidpointRounding.AwayFromZero).ToString("0.##") + " $/u" : "")
+                                </MudText>
+                                @if (IsPriceClampedToBounds(context))
+                                {
+                                    <MudTooltip Text="@GetClampTooltip(context)">
+                                        <MudIcon Icon="@MDIIcons.Outline.Information" Color="Color.Warning" Size="Size.Small" Class="d-flex align-center"/>
+                                    </MudTooltip>
+                                }
+                            </MudStack>
                         </MudTd>
                         <!-- share -->
                         <MudTd Class="px-1">
@@ -355,8 +379,8 @@
                                                      Converter="@CultureInvariantConverter.DotOrCommaDecimal"
                                                      Adornment="Adornment.End"
                                                      AdornmentText="% "
-                                                     Min="@(IsShareFreeForm ? Decimal.MinValue : 0)"
-                                                     Max="@(IsShareFreeForm ? Decimal.MaxValue : 100)"
+                                                     Min="@(IsShareDisplayUnbounded ? Decimal.MinValue : 0)"
+                                                     Max="@(IsShareDisplayUnbounded ? Decimal.MaxValue : 100)"
                                                      Variant="Variant.Outlined"
                                                      Step="@(0.1m)"
                                                      Value="@(context.Share * 100)"
@@ -419,17 +443,7 @@
                                             }
                                         }
 
-                                        @if (AdminServerMode)
-                                        {
-                                            <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.AdminLockTooltip")">
-                                                <MudIconButton Size="Size.Small"
-                                                               Class="ml-3"
-                                                               Color="@(Recipe.IsShareLocked ? Color.Warning : Color.Default)"
-                                                               Icon="@(Recipe.IsShareLocked ? MDIIcons.Filled.Lock : MDIIcons.Filled.LockOff)"
-                                                               OnClick="@(() => ToggleAdminLock())"/>
-                                            </MudTooltip>
-                                        }
-                                        else if (!Recipe.IsShareLocked)
+                                        @if (!IsAdminLockedForPlayer)
                                         {
                                             <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.UnlockTooltip")">
                                                 <MudIconButton Size="Size.Small"
@@ -464,6 +478,20 @@
                     </MudTooltip>
                 </MudStack>
             }
+
+            @if (AdminServerMode)
+            {
+                <MudStack Row AlignItems="AlignItems.Center" Spacing="2" Class="mt-n6">
+                    <MudSwitch T="bool"
+                               Color="Color.Warning"
+                               Value="Recipe.IsShareLocked"
+                               ValueChanged="OnAdminLockChanged"
+                               Label="@LocalizationService.GetTranslation("RecipeDialog.Share.AdminLockSwitch")"/>
+                    <MudTooltip Text="@LocalizationService.GetTranslation("RecipeDialog.Share.AdminLockTooltip")">
+                        <MudIcon Icon="@MDIIcons.Outline.Information" Color="Color.Warning" Size="Size.Small" Class="d-flex align-center"/>
+                    </MudTooltip>
+                </MudStack>
+            }
         </MudStack>
     </DialogContent>
 </MudDialog>
@@ -486,12 +514,18 @@
     [Parameter]
     public bool AdminServerMode { get; set; }
 
-    // Editing is free-form (no auto-rebalance to 100%) when the distribution is locked.
-    // Admin lock (Recipe.IsShareLocked) drives it in admin mode; the per-player LockShare otherwise.
-    private bool IsShareFreeForm => AdminServerMode ? Recipe.IsShareLocked : (_currentUserRecipe?.LockShare ?? false);
+    // Editing is free-form (no auto-rebalance to 100%) when the per-user cadenas (LockShare) is on.
+    // This stays a per-user editing aid in both modes — the admin can use it too to craft an
+    // arbitrary distribution before applying it server-wide via the admin lock switch.
+    private bool IsShareFreeForm => _currentUserRecipe?.LockShare ?? false;
 
     // A normal player viewing a recipe whose distribution is locked by the server admin: read-only.
     private bool IsAdminLockedForPlayer => !AdminServerMode && Recipe.IsShareLocked;
+
+    // The share field must not bound (and thus coerce) its value when the displayed shares may be
+    // free-form: either the per-user cadenas is on, or the recipe is admin-locked with values that
+    // the admin may have set outside the 0-100 range. Coercing would fire ValueChanged and reset it.
+    private bool IsShareDisplayUnbounded => IsShareFreeForm || Recipe.IsShareLocked;
 
     private const int PriceSaveDebounceMs = 250;
     private readonly Dictionary<Guid, CancellationTokenSource> _priceSaveDebounceByUserPriceId = [];
@@ -685,11 +719,11 @@
         StateHasChanged();
     }
 
-    // Admin: toggle the server-level lock of this recipe's output distribution.
+    // Admin: enable/disable the server-level lock of this recipe's output distribution.
     // When enabling, the current distribution is frozen onto every player of the server.
-    private async Task ToggleAdminLock()
+    private async Task OnAdminLockChanged(bool value)
     {
-        Recipe.IsShareLocked = !Recipe.IsShareLocked;
+        Recipe.IsShareLocked = value;
 
         await PersistAsync(context =>
         {
@@ -749,6 +783,32 @@
                         .SetProperty(x => x.IsReintegrated, element.DefaultIsReintegrated));
             }
         });
+    }
+
+    // The output price was clamped by the server min/max when it sits exactly on a defined bound.
+    private bool IsPriceClampedToBounds(UserElement product)
+    {
+        var itemOrTag = product.Element.ItemOrTag;
+
+        if (product.Price is null)
+        {
+            return false;
+        }
+
+        return (itemOrTag.MaxPrice is not null && product.Price == itemOrTag.MaxPrice)
+            || (itemOrTag.MinPrice is not null && product.Price == itemOrTag.MinPrice);
+    }
+
+    private string GetClampTooltip(UserElement product)
+    {
+        var itemOrTag = product.Element.ItemOrTag;
+
+        if (itemOrTag.MaxPrice is not null && product.Price == itemOrTag.MaxPrice)
+        {
+            return LocalizationService.GetTranslation("RecipeDialog.Price.ClampedMax", itemOrTag.MaxPrice.Value.ToString("0.##"));
+        }
+
+        return LocalizationService.GetTranslation("RecipeDialog.Price.ClampedMin", itemOrTag.MinPrice!.Value.ToString("0.##"));
     }
 
     private decimal ElementSum(List<UserElement> userElements, bool reverseDeduction = false, bool withReduction = true)
@@ -837,6 +897,13 @@
 
     private async Task UpdateShare(UserElement ue, decimal value)
     {
+        // Safety net: a player can never alter the shares of an admin-locked recipe (the field is
+        // read-only); ignore any value change, e.g. one fired by field coercion.
+        if (IsAdminLockedForPlayer)
+        {
+            return;
+        }
+
         var userElements = GetProductUserElements();
         var lockShare = IsShareFreeForm;
 

--- a/ecocraft/Components/Pages/PriceCalculator.razor
+++ b/ecocraft/Components/Pages/PriceCalculator.razor
@@ -890,17 +890,27 @@
 
                                         <MudTd Class="@(relatedUserElements.Count > 1 && _showDetailedRecipes ? "border-b-0" : "")">
                                             <MudStack Row AlignItems="AlignItems.Center" Spacing="0">
-                                                <MudTooltip Disabled="@(contextUserPrice.Price is not null)" Text="@LocalizationService.GetTranslation("PriceCalculator.PriceTooltip.isAutoCalculatedPrice")">
+                                                @{
+                                                    var isCostMinPrice = contextUserPrice.Price is not null && contextUserPrice.Price == context.MinPrice;
+                                                    var isCostMaxPrice = contextUserPrice.Price is not null && !context.IsTag && contextUserPrice.Price == context.MaxPrice;
+                                                    var showCostInfo = contextUserPrice.Price is null || isCostMinPrice || isCostMaxPrice;
+                                                }
+                                                <MudTooltip Disabled="@(!showCostInfo)"
+                                                            Text="@(contextUserPrice.Price is null
+                                                                    ? LocalizationService.GetTranslation("PriceCalculator.PriceTooltip.isAutoCalculatedPrice")
+                                                                    : isCostMinPrice
+                                                                        ? LocalizationService.GetTranslation("PriceCalculator.PriceTooltip.isMinPrice")
+                                                                        : LocalizationService.GetTranslation("PriceCalculator.PriceTooltip.isMaxPrice"))">
                                                     <MudNumericField T="decimal?"
                                                                      FullWidth="false"
-                                                                     Class="mt-0 small-adornment flex-no-grow rectangle-input"
+                                                                     Class="@($"mt-0 small-adornment flex-no-grow rectangle-input {(isCostMinPrice ? "min-price" : isCostMaxPrice ? "max-price" : "")}")"
                                                                      Style="width: 101px;"
                                                                      HideSpinButtons="true"
                                                                      Format="0.##"
                                                                      Disabled="true"
                                                                      Value="@contextUserPrice.Price"
                                                                      Culture="CultureInfo.CurrentUICulture"
-                                                                     Adornment="@(contextUserPrice.Price is not null ? Adornment.None : Adornment.End)"
+                                                                     Adornment="@(showCostInfo ? Adornment.End : Adornment.None)"
                                                                      AdornmentIcon="@MDIIcons.Outline.Information"
                                                                      AdornmentColor="Color.Warning"
                                                                      Variant="Variant.Outlined"/>
@@ -928,17 +938,24 @@
                                                 </div>
                                                 @{
                                                     var hasMarginPriceError = contextUserPrice.Price is not null && contextUserPrice.MarginPrice is null;
+                                                    var isMarginMinPrice = contextUserPrice.MarginPrice is not null && contextUserPrice.MarginPrice == context.MinPrice;
+                                                    var isMarginMaxPrice = contextUserPrice.MarginPrice is not null && !context.IsTag && contextUserPrice.MarginPrice == context.MaxPrice;
+                                                    var showMarginInfo = hasMarginPriceError || isMarginMinPrice || isMarginMaxPrice;
 
-                                                    <MudTooltip Disabled="@(!hasMarginPriceError)"
-                                                                Text="@LocalizationService.GetTranslation("PriceCalculator.MarginTooltip")">
+                                                    <MudTooltip Disabled="@(!showMarginInfo)"
+                                                                Text="@(hasMarginPriceError
+                                                                        ? LocalizationService.GetTranslation("PriceCalculator.MarginTooltip")
+                                                                        : isMarginMinPrice
+                                                                            ? LocalizationService.GetTranslation("PriceCalculator.PriceTooltip.isMinPrice")
+                                                                            : LocalizationService.GetTranslation("PriceCalculator.PriceTooltip.isMaxPrice"))">
                                                         <MudNumericField T="decimal?"
-                                                                         Class="mt-0 small-adornment flex-no-grow rectangle-input margin-price"
+                                                                         Class="@($"mt-0 small-adornment flex-no-grow rectangle-input margin-price {(isMarginMinPrice ? "min-price" : isMarginMaxPrice ? "max-price" : "")}")"
                                                                          Style="width: 85px"
                                                                          HideSpinButtons="true"
                                                                          Format="0.##"
                                                                          Disabled="true"
                                                                          Culture="CultureInfo.CurrentUICulture"
-                                                                         Adornment="@(hasMarginPriceError ? Adornment.End : Adornment.None)"
+                                                                         Adornment="@(showMarginInfo ? Adornment.End : Adornment.None)"
                                                                          AdornmentIcon="@MDIIcons.Outline.Information"
                                                                          AdornmentColor="Color.Warning"
                                                                          Value="@contextUserPrice.MarginPrice"

--- a/ecocraft/Components/Pages/ServerManagement.razor
+++ b/ecocraft/Components/Pages/ServerManagement.razor
@@ -2,6 +2,7 @@
 @implements IDisposable
 @using ecocraft.Models
 @using ecocraft.Extensions
+@using ecocraft.Components.Dialog
 @using ecocraft.Services
 @using ecocraft.Services.ImportData
 @using ecocraft.Services.DbServices
@@ -17,6 +18,10 @@
 @inject LocalizationService LocalizationService
 @inject ISnackbar Snackbar
 @inject IJSRuntime JsRuntime
+@inject IDialogService DialogService
+@inject DataContextDbService DataContextDbService
+@inject UserServerDataService UserServerDataService
+@inject PriceCalculatorService PriceCalculatorService
 @inject IDbContextFactory<EcoCraftDbContext> EcoCraftDbFactory
 
 <PageTitle>@LocalizationService.GetTranslation("NavMenu.NavAdmin") - Eco Gnome</PageTitle>
@@ -487,7 +492,41 @@
 						else
 						{
 							<MudTd>
-								<MudText Typo="Typo.body2">@LocalizationService.GetTranslation(context)</MudText>
+								<MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+									<MudText Typo="Typo.body2">@LocalizationService.GetTranslation(context)</MudText>
+									@{
+										var producingRecipes = GetRecipesProducingItem(context);
+									}
+									@if (producingRecipes.Count == 1)
+									{
+										<MudTooltip Text="@LocalizationService.GetTranslation("ServerManagement.Items.ConfigureRecipe")">
+											<MudIconButton Icon="@Icons.Material.Filled.Tune"
+											               Size="Size.Small"
+											               Color="Color.Primary"
+											               OnClick="@(() => OpenRecipeConfig(producingRecipes[0]))"/>
+										</MudTooltip>
+									}
+									else if (producingRecipes.Count > 1)
+									{
+										<MudMenu Dense="true" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft">
+											<ActivatorContent Context="menuActivator">
+												<MudTooltip Text="@LocalizationService.GetTranslation("ServerManagement.Items.ConfigureRecipe")">
+													<MudIconButton Icon="@Icons.Material.Filled.Tune"
+													               Size="Size.Small"
+													               Color="Color.Primary"/>
+												</MudTooltip>
+											</ActivatorContent>
+											<ChildContent>
+												@foreach (var producingRecipe in producingRecipes)
+												{
+													<MudMenuItem OnClick="@(() => OpenRecipeConfig(producingRecipe))">
+														@LocalizationService.GetTranslation(producingRecipe)
+													</MudMenuItem>
+												}
+											</ChildContent>
+										</MudMenu>
+									}
+								</MudStack>
 							</MudTd>
 							<MudTd>
 								<MudNumericField T="decimal?"
@@ -557,6 +596,7 @@
 	private Server? _copyServer;
 	private ItemOrTag? _selectedTag;
 	private List<(string, decimal)> _stats = [];
+	private Dictionary<Guid, List<Recipe>> _recipesByProducedItemId = new();
 	private readonly ItemOrTag _calorieCostPolicyRow = new()
 	{
 		Name = "__calorie_cost_policy_row__",
@@ -689,6 +729,86 @@
 		_stats.Add((LocalizationService.GetTranslation("ServerManagement.ServerSettings.Elements"), ContextService.CurrentServerData.Recipes.SelectMany(r => r.Elements).Count()));
 		_stats.Add((LocalizationService.GetTranslation("ServerManagement.ServerSettings.Items"), ContextService.CurrentServerData.ItemOrTags.Count(i => !i.IsTag)));
 		_stats.Add((LocalizationService.GetTranslation("ServerManagement.ServerSettings.Tags"), ContextService.CurrentServerData.ItemOrTags.Count(i => i.IsTag)));
+
+		BuildRecipesByProducedItem();
+	}
+
+	// Lookup item -> recipes that produce it, built once per server-data load to keep the
+	// item-table rendering cheap (the per-row action queries this map instead of scanning recipes).
+	private void BuildRecipesByProducedItem()
+	{
+		_recipesByProducedItemId = new Dictionary<Guid, List<Recipe>>();
+
+		if (ContextService.CurrentServerData is null)
+		{
+			return;
+		}
+
+		foreach (var recipe in ContextService.CurrentServerData.Recipes)
+		{
+			foreach (var element in recipe.Elements.Where(e => e.IsProduct()))
+			{
+				if (!_recipesByProducedItemId.TryGetValue(element.ItemOrTagId, out var recipes))
+				{
+					recipes = [];
+					_recipesByProducedItemId[element.ItemOrTagId] = recipes;
+				}
+
+				if (!recipes.Contains(recipe))
+				{
+					recipes.Add(recipe);
+				}
+			}
+		}
+
+		foreach (var recipes in _recipesByProducedItemId.Values)
+		{
+			recipes.Sort((a, b) => string.Compare(
+				LocalizationService.GetTranslation(a),
+				LocalizationService.GetTranslation(b),
+				StringComparison.CurrentCultureIgnoreCase));
+		}
+	}
+
+	private List<Recipe> GetRecipesProducingItem(ItemOrTag item)
+	{
+		return _recipesByProducedItemId.GetValueOrDefault(item.Id) ?? [];
+	}
+
+	// Opens the shared RecipeDialog in admin mode for a server recipe. The admin's default
+	// DataContext is used as the live preview/calculation context; the recipe is provisioned
+	// into it if absent. Edits target the server-level Element defaults / Recipe lock.
+	private async Task OpenRecipeConfig(Recipe recipe)
+	{
+		var adminDataContext = ContextService.CurrentUserServer!.DataContexts.First(d => d.IsDefault);
+		adminDataContext = await DataContextDbService.GetDataContextWithData(adminDataContext.Id, ContextService.CurrentServerData!);
+
+		if (recipe.GetCurrentUserRecipe(adminDataContext) is null)
+		{
+			await EcoCraftDbContext.ContextSaveAsync(EcoCraftDbFactory, context =>
+			{
+				UserServerDataService.AddUserRecipe(context, adminDataContext, ContextService.CurrentServerData!, recipe);
+				return Task.CompletedTask;
+			});
+
+			adminDataContext = await DataContextDbService.GetDataContextWithData(adminDataContext.Id, ContextService.CurrentServerData!);
+		}
+
+		await PriceCalculatorService.Calculate(adminDataContext, "ServerManagement:OpenRecipeConfig");
+
+		var parameters = new DialogParameters
+		{
+			["DataContext"] = adminDataContext,
+			["Recipe"] = recipe,
+			["AdminServerMode"] = true,
+			["RecalculateRequested"] = new Func<string, Task>(origin => PriceCalculatorService.Calculate(adminDataContext, $"ServerManagement:{origin}")),
+		};
+		var options = new DialogOptions { CloseOnEscapeKey = true, FullWidth = true, CloseButton = true, MaxWidth = MaxWidth.Large };
+
+		var dialog = await DialogService.ShowAsync<RecipeDialog>(LocalizationService.GetTranslation(recipe), parameters, options);
+		await dialog.Result;
+
+		await RefreshItemsTableAsync();
 	}
 
 	private async Task OnCalorieLockChangedAsync(bool value)

--- a/ecocraft/Components/Pages/ServerManagement.razor
+++ b/ecocraft/Components/Pages/ServerManagement.razor
@@ -492,41 +492,7 @@
 						else
 						{
 							<MudTd>
-								<MudStack Row AlignItems="AlignItems.Center" Spacing="1">
-									<MudText Typo="Typo.body2">@LocalizationService.GetTranslation(context)</MudText>
-									@{
-										var producingRecipes = GetRecipesProducingItem(context);
-									}
-									@if (producingRecipes.Count == 1)
-									{
-										<MudTooltip Text="@LocalizationService.GetTranslation("ServerManagement.Items.ConfigureRecipe")">
-											<MudIconButton Icon="@Icons.Material.Filled.Tune"
-											               Size="Size.Small"
-											               Color="Color.Primary"
-											               OnClick="@(() => OpenRecipeConfig(producingRecipes[0]))"/>
-										</MudTooltip>
-									}
-									else if (producingRecipes.Count > 1)
-									{
-										<MudMenu Dense="true" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft">
-											<ActivatorContent Context="menuActivator">
-												<MudTooltip Text="@LocalizationService.GetTranslation("ServerManagement.Items.ConfigureRecipe")">
-													<MudIconButton Icon="@Icons.Material.Filled.Tune"
-													               Size="Size.Small"
-													               Color="Color.Primary"/>
-												</MudTooltip>
-											</ActivatorContent>
-											<ChildContent>
-												@foreach (var producingRecipe in producingRecipes)
-												{
-													<MudMenuItem OnClick="@(() => OpenRecipeConfig(producingRecipe))">
-														@LocalizationService.GetTranslation(producingRecipe)
-													</MudMenuItem>
-												}
-											</ChildContent>
-										</MudMenu>
-									}
-								</MudStack>
+								<MudText Typo="Typo.body2">@LocalizationService.GetTranslation(context)</MudText>
 							</MudTd>
 							<MudTd>
 								<MudNumericField T="decimal?"
@@ -568,6 +534,48 @@
 					</PagerContent>
 				</MudTable>
 			</MudItem>
+			<MudItem lg="4" md="12">
+				<MudTable Items="@GetConfigurableRecipes()"
+				          Filter="new Func<Recipe, bool>(FilterRecipe)"
+				          Virtualize="false"
+				          FixedHeader="true"
+				          Height="400px"
+				          Dense="true"
+				          Hover="true">
+					<HeaderContent>
+						<MudTh>
+							<MudStack Row AlignItems="AlignItems.Center">
+								<MudText>@LocalizationService.GetTranslation("ServerManagement.Recipes.Title")</MudText>
+								<MudTextField @bind-Value="_searchRecipe" Immediate Placeholder="@LocalizationService.GetTranslation("Search")" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+							</MudStack>
+						</MudTh>
+						<MudTh Style="text-align:center">@LocalizationService.GetTranslation("ServerManagement.Recipes.Locked")</MudTh>
+					</HeaderContent>
+					<RowTemplate>
+						<MudTd>
+							<MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+								<EcoIcon Item="@GetRecipeMainProduct(context)"/>
+								<MudTooltip Text="@LocalizationService.GetTranslation("ServerManagement.Recipes.Configure")">
+									<MudLink Color="Color.Default" Typo="Typo.body2" OnClick="@(() => OpenRecipeConfig(context))">
+										@LocalizationService.GetTranslation(context)
+									</MudLink>
+								</MudTooltip>
+							</MudStack>
+						</MudTd>
+						<MudTd Style="text-align:center">
+							@if (context.IsShareLocked)
+							{
+								<MudTooltip Text="@LocalizationService.GetTranslation("ServerManagement.Recipes.LockedTooltip")">
+									<MudIcon Icon="@Icons.Material.Filled.Lock" Color="Color.Warning" Size="Size.Small"/>
+								</MudTooltip>
+							}
+						</MudTd>
+					</RowTemplate>
+					<PagerContent>
+						<MudTablePager PageSizeOptions="new[] { 25, 50, 100, 200 }"/>
+					</PagerContent>
+				</MudTable>
+			</MudItem>
 		}
 	</MudGrid>
 </MudContainer>
@@ -596,7 +604,8 @@
 	private Server? _copyServer;
 	private ItemOrTag? _selectedTag;
 	private List<(string, decimal)> _stats = [];
-	private Dictionary<Guid, List<Recipe>> _recipesByProducedItemId = new();
+	private string _searchRecipe = "";
+	private List<Recipe> _configurableRecipes = [];
 	private readonly ItemOrTag _calorieCostPolicyRow = new()
 	{
 		Name = "__calorie_cost_policy_row__",
@@ -730,49 +739,43 @@
 		_stats.Add((LocalizationService.GetTranslation("ServerManagement.ServerSettings.Items"), ContextService.CurrentServerData.ItemOrTags.Count(i => !i.IsTag)));
 		_stats.Add((LocalizationService.GetTranslation("ServerManagement.ServerSettings.Tags"), ContextService.CurrentServerData.ItemOrTags.Count(i => i.IsTag)));
 
-		BuildRecipesByProducedItem();
+		BuildConfigurableRecipes();
 	}
 
-	// Lookup item -> recipes that produce it, built once per server-data load to keep the
-	// item-table rendering cheap (the per-row action queries this map instead of scanning recipes).
-	private void BuildRecipesByProducedItem()
+	// A recipe is "configurable" for issue #85 when it has several outputs: only then do the
+	// output share and reintegration matter. Built once per server-data load.
+	private void BuildConfigurableRecipes()
 	{
-		_recipesByProducedItemId = new Dictionary<Guid, List<Recipe>>();
-
-		if (ContextService.CurrentServerData is null)
-		{
-			return;
-		}
-
-		foreach (var recipe in ContextService.CurrentServerData.Recipes)
-		{
-			foreach (var element in recipe.Elements.Where(e => e.IsProduct()))
-			{
-				if (!_recipesByProducedItemId.TryGetValue(element.ItemOrTagId, out var recipes))
-				{
-					recipes = [];
-					_recipesByProducedItemId[element.ItemOrTagId] = recipes;
-				}
-
-				if (!recipes.Contains(recipe))
-				{
-					recipes.Add(recipe);
-				}
-			}
-		}
-
-		foreach (var recipes in _recipesByProducedItemId.Values)
-		{
-			recipes.Sort((a, b) => string.Compare(
-				LocalizationService.GetTranslation(a),
-				LocalizationService.GetTranslation(b),
-				StringComparison.CurrentCultureIgnoreCase));
-		}
+		_configurableRecipes = ContextService.CurrentServerData is null
+			? []
+			: ContextService.CurrentServerData.Recipes
+				.Where(r => r.Elements.Count(e => e.IsProduct()) > 1)
+				.OrderBy(r => LocalizationService.GetTranslation(r), StringComparer.CurrentCultureIgnoreCase)
+				.ToList();
 	}
 
-	private List<Recipe> GetRecipesProducingItem(ItemOrTag item)
+	private List<Recipe> GetConfigurableRecipes()
 	{
-		return _recipesByProducedItemId.GetValueOrDefault(item.Id) ?? [];
+		return _configurableRecipes;
+	}
+
+	private ItemOrTag? GetRecipeMainProduct(Recipe recipe)
+	{
+		return recipe.Elements
+			.Where(e => e.IsProduct())
+			.OrderBy(e => e.Index)
+			.FirstOrDefault()?.ItemOrTag;
+	}
+
+	private bool FilterRecipe(Recipe recipe)
+	{
+		if (string.IsNullOrWhiteSpace(_searchRecipe))
+		{
+			return true;
+		}
+
+		return recipe.Name.Contains(_searchRecipe, StringComparison.OrdinalIgnoreCase)
+		       || LocalizationService.GetTranslation(recipe).Contains(_searchRecipe, StringComparison.OrdinalIgnoreCase);
 	}
 
 	// Opens the shared RecipeDialog in admin mode for a server recipe. The admin's default
@@ -780,35 +783,43 @@
 	// into it if absent. Edits target the server-level Element defaults / Recipe lock.
 	private async Task OpenRecipeConfig(Recipe recipe)
 	{
-		var adminDataContext = ContextService.CurrentUserServer!.DataContexts.First(d => d.IsDefault);
-		adminDataContext = await DataContextDbService.GetDataContextWithData(adminDataContext.Id, ContextService.CurrentServerData!);
-
-		if (recipe.GetCurrentUserRecipe(adminDataContext) is null)
+		try
 		{
-			await EcoCraftDbContext.ContextSaveAsync(EcoCraftDbFactory, context =>
-			{
-				UserServerDataService.AddUserRecipe(context, adminDataContext, ContextService.CurrentServerData!, recipe);
-				return Task.CompletedTask;
-			});
-
+			var adminDataContext = ContextService.CurrentUserServer!.DataContexts.First(d => d.IsDefault);
 			adminDataContext = await DataContextDbService.GetDataContextWithData(adminDataContext.Id, ContextService.CurrentServerData!);
+
+			if (recipe.GetCurrentUserRecipe(adminDataContext) is null)
+			{
+				await EcoCraftDbContext.ContextSaveAsync(EcoCraftDbFactory, context =>
+				{
+					UserServerDataService.AddUserRecipe(context, adminDataContext, ContextService.CurrentServerData!, recipe);
+					return Task.CompletedTask;
+				});
+
+				adminDataContext = await DataContextDbService.GetDataContextWithData(adminDataContext.Id, ContextService.CurrentServerData!);
+			}
+
+			await PriceCalculatorService.Calculate(adminDataContext, "ServerManagement:OpenRecipeConfig");
+
+			var parameters = new DialogParameters
+			{
+				["DataContext"] = adminDataContext,
+				["Recipe"] = recipe,
+				["AdminServerMode"] = true,
+				["RecalculateRequested"] = new Func<string, Task>(origin => PriceCalculatorService.Calculate(adminDataContext, $"ServerManagement:{origin}")),
+			};
+			var options = new DialogOptions { CloseOnEscapeKey = true, FullWidth = true, CloseButton = true, MaxWidth = MaxWidth.Large };
+
+			var dialog = await DialogService.ShowAsync<RecipeDialog>(LocalizationService.GetTranslation(recipe), parameters, options);
+			await dialog.Result;
+
+			await RefreshItemsTableAsync();
 		}
-
-		await PriceCalculatorService.Calculate(adminDataContext, "ServerManagement:OpenRecipeConfig");
-
-		var parameters = new DialogParameters
+		catch (Exception ex)
 		{
-			["DataContext"] = adminDataContext,
-			["Recipe"] = recipe,
-			["AdminServerMode"] = true,
-			["RecalculateRequested"] = new Func<string, Task>(origin => PriceCalculatorService.Calculate(adminDataContext, $"ServerManagement:{origin}")),
-		};
-		var options = new DialogOptions { CloseOnEscapeKey = true, FullWidth = true, CloseButton = true, MaxWidth = MaxWidth.Large };
-
-		var dialog = await DialogService.ShowAsync<RecipeDialog>(LocalizationService.GetTranslation(recipe), parameters, options);
-		await dialog.Result;
-
-		await RefreshItemsTableAsync();
+			Console.WriteLine(ex);
+			Snackbar.Add($"{LocalizationService.GetTranslation("ServerManagement.Recipes.OpenError")}: {ex.Message}", Severity.Error);
+		}
 	}
 
 	private async Task OnCalorieLockChangedAsync(bool value)

--- a/ecocraft/Migrations/20260607120000_AddRecipeShareLock.cs
+++ b/ecocraft/Migrations/20260607120000_AddRecipeShareLock.cs
@@ -1,0 +1,33 @@
+using ecocraft.Models;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ecocraft.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(EcoCraftDbContext))]
+    [Migration("20260607120000_AddRecipeShareLock")]
+    public partial class AddRecipeShareLock : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsShareLocked",
+                table: "Recipe",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsShareLocked",
+                table: "Recipe");
+        }
+    }
+}

--- a/ecocraft/Migrations/EcoCraftDbContextModelSnapshot.cs
+++ b/ecocraft/Migrations/EcoCraftDbContextModelSnapshot.cs
@@ -495,6 +495,9 @@ namespace ecocraft.Migrations
                     b.Property<bool>("IsDefault")
                         .HasColumnType("boolean");
 
+                    b.Property<bool>("IsShareLocked")
+                        .HasColumnType("boolean");
+
                     b.Property<Guid>("LaborId")
                         .HasColumnType("uuid");
 

--- a/ecocraft/Models/Models.cs
+++ b/ecocraft/Models/Models.cs
@@ -47,6 +47,7 @@ public class Recipe: IHasLocalizedName
     [ForeignKey("DynamicValue")] public Guid LaborId { get; set; }
     [ForeignKey("CraftingTable")] public Guid CraftingTableId { get; set; }
     [ForeignKey("Server")] public Guid ServerId { get; set; }
+    public bool IsShareLocked { get; set; } = false;
 
     public LocalizedField LocalizedName { get; set; }
     public DynamicValue CraftMinutes { get; set; }

--- a/ecocraft/Services/DbServices/ElementDbService.cs
+++ b/ecocraft/Services/DbServices/ElementDbService.cs
@@ -55,6 +55,20 @@ public class ElementDbService(IDbContextFactory<EcoCraftDbContext> factory) : IG
 		context.Attach(CloneForDb(element)).State = EntityState.Modified;
 	}
 
+	public void UpdateDefaultShareConfig(EcoCraftDbContext context, Element element)
+	{
+		var stub = new Element
+		{
+			Id = element.Id,
+			DefaultShare = element.DefaultShare,
+			DefaultIsReintegrated = element.DefaultIsReintegrated,
+		};
+		var entry = context.Entry(stub);
+		entry.State = EntityState.Unchanged;
+		entry.Property(x => x.DefaultShare).IsModified = true;
+		entry.Property(x => x.DefaultIsReintegrated).IsModified = true;
+	}
+
 	public void Destroy(EcoCraftDbContext context, Element element)
 	{
 		var entity = new Element { Id = element.Id };

--- a/ecocraft/Services/DbServices/RecipeDbService.cs
+++ b/ecocraft/Services/DbServices/RecipeDbService.cs
@@ -81,6 +81,7 @@ public class RecipeDbService(IDbContextFactory<EcoCraftDbContext> factory) : IGe
 			LaborId = recipe.Labor.Id,
 			CraftingTableId = recipe.CraftingTable.Id,
 			ServerId = recipe.Server.Id,
+			IsShareLocked = recipe.IsShareLocked,
 		};
 	}
 
@@ -92,6 +93,14 @@ public class RecipeDbService(IDbContextFactory<EcoCraftDbContext> factory) : IGe
 	public void UpdateAll(EcoCraftDbContext context, Recipe recipe)
 	{
 		context.Attach(CloneForDb(recipe)).State = EntityState.Modified;
+	}
+
+	public void UpdateShareLock(EcoCraftDbContext context, Recipe recipe)
+	{
+		var stub = new Recipe { Id = recipe.Id, IsShareLocked = recipe.IsShareLocked };
+		var entry = context.Entry(stub);
+		entry.State = EntityState.Unchanged;
+		entry.Property(x => x.IsShareLocked).IsModified = true;
 	}
 
 	public void Destroy(EcoCraftDbContext context, Recipe recipe)

--- a/ecocraft/Services/PriceCalculatorService.cs
+++ b/ecocraft/Services/PriceCalculatorService.cs
@@ -71,6 +71,10 @@ public class PriceCalculatorService(
         public HashSet<Guid> DirtyUserElementIds { get; } = [];
         public HashSet<Guid> DirtyUserCraftingTableIds { get; } = [];
 
+        // Real (unclamped) per-unit output cost, kept so the margin can be computed
+        // on the real price even when the stored cost is clamped to the item min/max bounds.
+        public Dictionary<Guid, decimal?> RealProductPriceByUserElementId { get; } = [];
+
         public DynamicValueCalculationContext DynamicValueCalculationContext =>
             _dynamicValueCalculationContext ??= new DynamicValueCalculationContext
             {
@@ -457,8 +461,13 @@ public class PriceCalculatorService(
                                 continue;
                             }
 
-                            var computedProductPrice = ingredientCostSum * product.Share / finalQuantity;
-                            calculationContext.TrySetUserElementPrice(product, computedProductPrice, product.IsMarginPrice);
+                            // Real (unclamped) output cost. The stored cost is clamped to the
+                            // produced item min/max bounds, but the margin must be computed on the
+                            // real price (then clamped in turn) — see issue #84.
+                            var realProductPrice = ingredientCostSum * product.Share / finalQuantity;
+                            var clampedProductPrice = ClampToItemBounds(realProductPrice, product.Element.ItemOrTag);
+                            calculationContext.RealProductPriceByUserElementId[product.Id] = realProductPrice;
+                            calculationContext.TrySetUserElementPrice(product, clampedProductPrice, product.IsMarginPrice);
 
                             var productUserPrice = calculationContext.GetUserPrice(product.Element.ItemOrTag);
                             if (productUserPrice is null || productUserPrice.OverrideIsBought || productUserPrice.Price is not null)
@@ -468,7 +477,7 @@ public class PriceCalculatorService(
 
                             if (productUserPrice.PrimaryUserElement == product)
                             {
-                                SetUserPriceWithMargin(calculationContext, productUserPrice, product.Price, marginType);
+                                SetUserPriceWithMargin(calculationContext, productUserPrice, product.Price, realProductPrice, product.Element.ItemOrTag, marginType);
                             }
                             else if (productUserPrice.PrimaryUserElement is null)
                             {
@@ -481,7 +490,11 @@ public class PriceCalculatorService(
 
                                 if (relatedUserElements.All(ue => ue.Price is not null))
                                 {
-                                    SetUserPriceWithMargin(calculationContext, productUserPrice, relatedUserElements.Min(ue => ue.Price), marginType);
+                                    // Clamping shares the same bounds for every producer of this item, so the
+                                    // cheapest stored (clamped) cost is also the cheapest real cost.
+                                    var cheapest = relatedUserElements.OrderBy(ue => ue.Price).First();
+                                    var cheapestRealPrice = calculationContext.RealProductPriceByUserElementId.GetValueOrDefault(cheapest.Id) ?? cheapest.Price;
+                                    SetUserPriceWithMargin(calculationContext, productUserPrice, cheapest.Price, cheapestRealPrice, product.Element.ItemOrTag, marginType);
                                 }
                             }
                         }
@@ -647,11 +660,14 @@ public class PriceCalculatorService(
 
     private sealed record FuelItemGroup(ItemOrTag? Tag, List<ItemOrTag> Items);
 
-    private static void SetUserPriceWithMargin(CalculationContext calculationContext, UserPrice userPrice, decimal? basePrice, MarginType marginType)
+    // storedPrice is the cost stored on the UserPrice (already clamped to the item bounds).
+    // marginBasePrice is the real, unclamped cost the margin is computed from; the resulting
+    // margin is then clamped to the same item bounds (issue #84).
+    private static void SetUserPriceWithMargin(CalculationContext calculationContext, UserPrice userPrice, decimal? storedPrice, decimal? marginBasePrice, ItemOrTag clampItemOrTag, MarginType marginType)
     {
         decimal? marginPrice;
 
-        if (basePrice is null || userPrice.UserMargin is null)
+        if (marginBasePrice is null || userPrice.UserMargin is null)
         {
             marginPrice = null;
         }
@@ -662,17 +678,22 @@ public class PriceCalculatorService(
             switch (marginType)
             {
                 case MarginType.MarkUp:
-                    marginPrice = basePrice * (1 + userPrice.UserMargin.Margin / 100);
+                    marginPrice = marginBasePrice * (1 + userPrice.UserMargin.Margin / 100);
                     break;
                 case MarginType.GrossMargin:
                 {
                     var divisionFactor = 1 - userPrice.UserMargin.Margin / 100;
                     if (divisionFactor > 0)
                     {
-                        marginPrice = basePrice / divisionFactor;
+                        marginPrice = marginBasePrice / divisionFactor;
                     }
                     break;
                 }
+            }
+
+            if (marginPrice is not null)
+            {
+                marginPrice = ClampToItemBounds(marginPrice.Value, clampItemOrTag);
             }
 
             if (marginPrice is not null && userPrice.UserMargin.Rounding != RoundingMode.None)
@@ -681,7 +702,23 @@ public class PriceCalculatorService(
             }
         }
 
-        calculationContext.TrySetUserPrice(userPrice, basePrice, marginPrice);
+        calculationContext.TrySetUserPrice(userPrice, storedPrice, marginPrice);
+    }
+
+    // Bounds a price to the item min/max defined by the server admin. No-op when a bound is null.
+    private static decimal ClampToItemBounds(decimal price, ItemOrTag itemOrTag)
+    {
+        if (itemOrTag.MinPrice is not null && price < itemOrTag.MinPrice.Value)
+        {
+            price = itemOrTag.MinPrice.Value;
+        }
+
+        if (itemOrTag.MaxPrice is not null && price > itemOrTag.MaxPrice.Value)
+        {
+            price = itemOrTag.MaxPrice.Value;
+        }
+
+        return price;
     }
 
     // Below 1$ → no rounding. Above:

--- a/ecocraft/wwwroot/assets/lang/en_US.json
+++ b/ecocraft/wwwroot/assets/lang/en_US.json
@@ -92,7 +92,9 @@
             "EquilibrateTooltip": "Split by quantity between products.",
             "FirstOnlyTooltip": "Grant 100% to first product and zero to the rest. Choose this if you consider other products to be garbage.",
             "HonestTooltip": "Grant 80% to first product and split the rest equally.",
-            "UnlockTooltip": "Disables automatic balancing, allowing manual editing of all values, including going above or below a total of 100%."
+            "UnlockTooltip": "Disables automatic balancing, allowing manual editing of all values, including going above or below a total of 100%.",
+            "AdminLockTooltip": "Lock this recipe's distribution for the whole server. While locked, the current shares and reintegration are imposed on every player and overwrite their own settings.",
+            "AdminLockedTooltip": "This distribution is locked by the server administrator and cannot be changed."
         },
         "Static": "static",
         "TotalCost": "Total cost:",
@@ -177,7 +179,8 @@
             "Min": "Min price",
             "Min.Tooltip": "Clear min prices",
             "Default": "Default price",
-            "Default.Tooltip": "Clear default prices"
+            "Default.Tooltip": "Clear default prices",
+            "ConfigureRecipe": "Configure the recipe distribution (share / reintegration) for this item"
         },
         "Members": {
             "DemoteAdmin": "Demote Admin",

--- a/ecocraft/wwwroot/assets/lang/en_US.json
+++ b/ecocraft/wwwroot/assets/lang/en_US.json
@@ -93,8 +93,13 @@
             "FirstOnlyTooltip": "Grant 100% to first product and zero to the rest. Choose this if you consider other products to be garbage.",
             "HonestTooltip": "Grant 80% to first product and split the rest equally.",
             "UnlockTooltip": "Disables automatic balancing, allowing manual editing of all values, including going above or below a total of 100%.",
+            "AdminLockSwitch": "Lock and apply to all players",
             "AdminLockTooltip": "Lock this recipe's distribution for the whole server. While locked, the current shares and reintegration are imposed on every player and overwrite their own settings.",
             "AdminLockedTooltip": "This distribution is locked by the server administrator and cannot be changed."
+        },
+        "Price": {
+            "ClampedMax": "Price capped at the server maximum ({max} $).",
+            "ClampedMin": "Price raised to the server minimum ({min} $)."
         },
         "Static": "static",
         "TotalCost": "Total cost:",
@@ -179,8 +184,14 @@
             "Min": "Min price",
             "Min.Tooltip": "Clear min prices",
             "Default": "Default price",
-            "Default.Tooltip": "Clear default prices",
-            "ConfigureRecipe": "Configure the recipe distribution (share / reintegration) for this item"
+            "Default.Tooltip": "Clear default prices"
+        },
+        "Recipes": {
+            "Title": "Multi-output recipes",
+            "Locked": "Locked",
+            "LockedTooltip": "The output distribution of this recipe is locked for all players.",
+            "Configure": "Configure the output distribution (share / reintegration)",
+            "OpenError": "Unable to open the recipe configuration"
         },
         "Members": {
             "DemoteAdmin": "Demote Admin",

--- a/ecocraft/wwwroot/assets/lang/fr.json
+++ b/ecocraft/wwwroot/assets/lang/fr.json
@@ -92,7 +92,9 @@
             "EquilibrateTooltip": "Répartir par quantité entre les produits.",
             "FirstOnlyTooltip": "Accorder 100 % au premier produit et zéro aux autres. Choisissez cette option si vous considérez les autres produits comme des déchets.",
             "HonestTooltip": "Accorder 80 % au premier produit et répartir le reste de manière égale.",
-            "UnlockTooltip": "Désactive l'équilibrage automatique et permet l'édition manuelle de toutes les valeurs, y compris le dépassement d'un total de 100 %."
+            "UnlockTooltip": "Désactive l'équilibrage automatique et permet l'édition manuelle de toutes les valeurs, y compris le dépassement d'un total de 100 %.",
+            "AdminLockTooltip": "Verrouille la répartition de cette recette pour tout le serveur. Une fois verrouillée, les parts et la réintégration actuelles sont imposées à tous les joueurs et écrasent leurs propres réglages.",
+            "AdminLockedTooltip": "Cette répartition est verrouillée par l'administrateur du serveur et ne peut pas être modifiée."
         },
         "Static": "statique",
         "TotalCost": "Coût total :",
@@ -171,7 +173,8 @@
             "Min": "Prix min",
             "Min.Tooltip": "Effacer les prix min",
             "Default": "Prix par défaut",
-            "Default.Tooltip": "Effacer les prix par défaut"
+            "Default.Tooltip": "Effacer les prix par défaut",
+            "ConfigureRecipe": "Configurer la répartition de recette (parts / réintégration) pour cet item"
         },
         "Members": {
             "DemoteAdmin": "Rétrograder l'administrateur",

--- a/ecocraft/wwwroot/assets/lang/fr.json
+++ b/ecocraft/wwwroot/assets/lang/fr.json
@@ -93,8 +93,13 @@
             "FirstOnlyTooltip": "Accorder 100 % au premier produit et zéro aux autres. Choisissez cette option si vous considérez les autres produits comme des déchets.",
             "HonestTooltip": "Accorder 80 % au premier produit et répartir le reste de manière égale.",
             "UnlockTooltip": "Désactive l'équilibrage automatique et permet l'édition manuelle de toutes les valeurs, y compris le dépassement d'un total de 100 %.",
+            "AdminLockSwitch": "Verrouiller et appliquer à tous les joueurs",
             "AdminLockTooltip": "Verrouille la répartition de cette recette pour tout le serveur. Une fois verrouillée, les parts et la réintégration actuelles sont imposées à tous les joueurs et écrasent leurs propres réglages.",
             "AdminLockedTooltip": "Cette répartition est verrouillée par l'administrateur du serveur et ne peut pas être modifiée."
+        },
+        "Price": {
+            "ClampedMax": "Prix plafonné au maximum du serveur ({max} $).",
+            "ClampedMin": "Prix relevé au minimum du serveur ({min} $)."
         },
         "Static": "statique",
         "TotalCost": "Coût total :",
@@ -173,8 +178,14 @@
             "Min": "Prix min",
             "Min.Tooltip": "Effacer les prix min",
             "Default": "Prix par défaut",
-            "Default.Tooltip": "Effacer les prix par défaut",
-            "ConfigureRecipe": "Configurer la répartition de recette (parts / réintégration) pour cet item"
+            "Default.Tooltip": "Effacer les prix par défaut"
+        },
+        "Recipes": {
+            "Title": "Recettes multi-produits",
+            "Locked": "Verrouillée",
+            "LockedTooltip": "La répartition des produits de cette recette est verrouillée pour tous les joueurs.",
+            "Configure": "Configurer la répartition des produits (parts / réintégration)",
+            "OpenError": "Impossible d'ouvrir la configuration de la recette"
         },
         "Members": {
             "DemoteAdmin": "Rétrograder l'administrateur",


### PR DESCRIPTION
Closes #84
Closes #85

## #85 — Admin lock for recipe output distribution

Server admins can now fix the output **share** and **reintegration** of multi-output recipes and impose them on every player of the server.

- New **"Multi-output recipes"** table on the server admin page (only recipes with ≥ 2 outputs — the only ones where share/reintegration matters). The recipe name is clickable and opens the shared `RecipeDialog` in **admin mode**.
- In admin mode the per-user **cadenas keeps its original role** (free-form editing / disable the auto-rebalance to 100%), so the admin can craft an arbitrary distribution.
- A dedicated **"Lock and apply to all players"** switch freezes the current distribution (`Recipe.IsShareLocked`): the shares and reintegration are pushed to and overwrite every player's settings.
- For players, a locked recipe is **read-only**: greyed controls + an orange info icon/tooltip on both the share and reintegration fields.
- **Without lock**, admin edits only update the server-side defaults (new players inherit them); existing players are untouched. **Unlocking** keeps the imposed values and simply gives editing back.

## #84 — Apply item min/max to recipe outputs

- Recipe output prices are now clamped to the produced item's **min/max** bounds.
- The **cost** is clamped, and the **margin** is computed on the real (unclamped) price *before* being clamped in turn — as requested in the issue (the margin must not be derived from an already-bounded price).
- The price calculator (sell fields) and the recipe dialog show an **orange info indicator + tooltip** when an output price is capped/floored.

## Data / migration
- New column `Recipe.IsShareLocked` (migration `AddRecipeShareLock`). The imposed values reuse the existing `Element.DefaultShare` / `DefaultIsReintegrated` (already propagated to new players).

## Testing
- Verified the min/max clamping on cost and margin (margin computed from the real price).
- Verified the admin lock end-to-end with two accounts: push/overwrite on lock, read-only indicators for players, free-form (incl. negative) shares displayed without being reset, and unlock keeping imposed values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
